### PR TITLE
Demo of issue with stl containers in static section

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <string>
 #include <fstream>
+#include <vector>
 
 #define __IMPORT(module, name) __attribute__((__import_module__(#module), __import_name__(#name)))
 #define __EXPORT(name) __attribute__((__export_name__(#name)))
@@ -14,7 +15,19 @@ extern "C" void ic0_msg_arg_data_copy(char * buf, std::size_t offset, std::size_
 extern "C" void ic0_msg_reply() __IMPORT(ic0, msg_reply);
 extern "C" void ic0_msg_reply_data_append(const char * buf, std::size_t length) __IMPORT(ic0, msg_reply_data_append);
 
+std::vector<uint64_t> vec1(2, 0);
+
 extern "C" __EXPORT(canister_query greet) __attribute__((noinline)) void greet()  {
+    // Work with vector defined in static memory
+    // -> data is persisted across calls, using Orthogonal persistence
+    ++vec1[0];
+    ++vec1[1];
+    // TODO: currently, the above access to vec1 results in an error:
+    /*
+    Error: Failed update call.
+    Caused by: The replica returned a rejection error: reject code CanisterError, reject message Error from Canister bkyz2-fmaaa-aaaaa-qaaaq-cai: Canister trapped: heap out of bounds, error code None
+    */
+    // See: https://forum.dfinity.org/t/orthogonal-persistence-of-c-data-structures-on-the-internet-computer-a-study/21828/6?u=icpp 
 
     int n = ic0_msg_arg_data_size();
     char buf[n];

--- a/src/run.sh
+++ b/src/run.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-/opt/wasi-sdk/bin/clang++ main.cpp -L../../ic-wasi-polyfill/target/wasm32-wasi/release -lic_wasi_polyfill -o main.wasm
+/opt/wasi-sdk/bin/clang++ -fno-exceptions main.cpp -L../../ic-wasi-polyfill/target/wasm32-wasi/release -lic_wasi_polyfill -o main.wasm
+wasm2wat main.wasm > main.wat
 wasi2ic main.wasm nowasi.wasm
 wasm2wat nowasi.wasm > nowasi.wat
 dfx canister install -y --mode reinstall --wasm nowasi.wasm demo2_backend


### PR DESCRIPTION
*(Note: this is not a bug or issue in wasi2ic, but perhaps it can be elegantly handled by wasi2ic)*

Currently, this updated demo2 fails with an error:

```
Error: Failed update call.
    Caused by: The replica returned a rejection error: reject code CanisterError, reject message Error from Canister bkyz2-fmaaa-aaaaa-qaaaq-cai: Canister trapped: heap out of bounds, error code None
```

Defining STL containers that use dynamic heap memory directly in global/static section is not working. Not only are they not persisted, just adding these to the global/static section corrupts the canister memory, even if you’re not using them at all.

An investigation by Ulan from DFINITY can be found in a [forum thread](https://forum.dfinity.org/t/orthogonal-persistence-of-c-data-structures-on-the-internet-computer-a-study/21828/6?u=icpp), which concludes:

- The root cause of the issue is that the constructors of static classes (e.g. vec1) are not invoked at startup (canister install / upgrade).
- Since the constructors are not invoked, the containers are empty (e.g. vec1.size() == 0). I verified this by printing the size immediately after installation.
- The “heap out of bounds” error happens because of an attempt to access elements of an empty container.
- The main.wasm has a _start function that invokes the constructors.
- The nowasi.wasm doesn’t have that function anymore (optimized away?).
- The fix would be to keep the _start function and
  - either export it as a (start) function. IC guarantees to invoke an exported function with name (start) at canister startup: https://internetcomputer.org/docs/current/references/ic-interface-spec#system-api-module
  - or call the _start function as the first thing in canister_init / canister_post_upgrade.

The purpose of this PR is to first figure out how to get this to work, and once it is working, merge it into the demo2 example, to demonstrate how to use stl containers defined in the static section.

